### PR TITLE
Fix [name].css duplication on build and system.css build-path

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -2,7 +2,6 @@
 const path = require("path")
 const utils = require("./utils")
 const config = require("../config")
-const MiniCssExtractPlugin = require("mini-css-extract-plugin")
 const { VueLoaderPlugin } = require("vue-loader")
 
 function resolve(dir) {
@@ -73,7 +72,7 @@ module.exports = {
       },
     ],
   },
-  plugins: [new VueLoaderPlugin(), new MiniCssExtractPlugin("style.css")],
+  plugins: [new VueLoaderPlugin()],
   node: {
     // prevent webpack from injecting useless setImmediate polyfill because Vue
     // source contains it (although only uses it if it's native).

--- a/build/webpack.system.conf.js
+++ b/build/webpack.system.conf.js
@@ -48,7 +48,7 @@ const webpackConfig = merge(baseWebpackConfig, {
     }),
     // extract css into its own file
     new MiniCssExtractPlugin({
-      filename: utils.assetsPath("[name].css"),
+      filename: utils.assetsSystemPath("[name].css"),
     }),
     // Compress extracted CSS. We are using this plugin so that possible
     // duplicated CSS from different components can be deduped.


### PR DESCRIPTION
Currently, the build-script will create two CSS files with one being located in the dist-root folder. Those duplicates are also included in the created HTML files which isn't ideal, especially for production.

Also looks like the path of the `system.css` has been changed by upgrading to webpack v4.

Not sure if that is the intended behavior. If so please ignore this PR.

Kind regards.