### PR TITLE
help with using design system as npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "theo": "theo ./src/tokens/tokens.yml --transform web --format map.scss,scss,raw.json,json --dest ./src/assets/tokens",
     "theo:onchange": "onchange \"./src/tokens/*.yml\" -- npm run theo",
     "test": "npm-run-all theo unit",
-    "precommit": "pretty-quick --staged"
+    "precommit": "pretty-quick --staged",
+    "prepare": "npm install npm-run-all && npm install theo && npm run build:system"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This change is a really tiny one but it enables anyone wanting to use the vue-design-system as a module to actually do it without having to clone and build locally.
With this little line you only can install the design system from the github repository and thus use it easily in an application that's shared among several developpers.
You can read more about in my forked wiki : https://github.com/JustineVuillemot/vue-design-system/wiki/getting-started#installing-it-from-a-distant-repository