### PR TITLE
add missing postcss-loader (fixes #128)

### DIFF
--- a/config/docs.config.js
+++ b/config/docs.config.js
@@ -175,6 +175,7 @@ module.exports = {
           use: [
             "style-loader",
             "css-loader",
+            "postcss-loader",
             "sass-loader",
             {
               loader: "sass-resources-loader",


### PR DESCRIPTION
This enables postcss-loader in Design System Docs context and thus e.g. makes autoprefixer work.